### PR TITLE
#162160512 remove auth from get following/followers

### DIFF
--- a/controllers/articleController.js
+++ b/controllers/articleController.js
@@ -2,7 +2,15 @@
 import utility from '../lib/utility';
 import helper from '../lib/helper';
 import {
-  Articles, Reactions, Bookmark, FavoriteArticle, Rating, ReportArticle, ArticleComment,
+  Articles,
+  Reactions,
+  Bookmark,
+  FavoriteArticle,
+  Rating,
+  ReportArticle,
+  ArticleComment,
+  User,
+  Profiles,
 } from '../models';
 
 /**
@@ -555,6 +563,18 @@ const getUserFavorites = async (req, res) => {
           {
             model: Reactions,
             as: 'reactions',
+          },
+          {
+            model: User,
+            as: 'user',
+            required: false,
+            attributes: ['firstname', 'lastname'],
+            include: {
+              model: Profiles,
+              as: 'profile',
+              required: false,
+              attributes: ['image']
+            }
           },
         ]
       }]

--- a/routes/api/user.js
+++ b/routes/api/user.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import authenticate from '../../middleware/authentication';
+import authenticate, { allowVisitors } from '../../middleware/authentication';
 import userController from '../../controllers/userController';
 import { acceptableValues } from '../../middleware/validation';
 import utility from '../../lib/utility';
@@ -8,8 +8,8 @@ const router = express.Router();
 
 router.post('/user/follow/:userId', authenticate, userController.follow);
 router.delete('/user/follow/:userId', authenticate, userController.unfollow);
-router.get('/user/followed/:userId', authenticate, userController.listOfFollowedUsers);
-router.get('/user/followers/:userId', authenticate, userController.listOfFollowers);
+router.get('/user/followed/:userId', allowVisitors, userController.listOfFollowedUsers);
+router.get('/user/followers/:userId', allowVisitors, userController.listOfFollowers);
 router.put('/user/notification/on/:setting', authenticate, acceptableValues(utility.notificationRule), userController.setNotification);
 router.put('/user/notification/off/:setting', authenticate, acceptableValues(utility.notificationRule), userController.unsetNotification);
 router.get('/user/notification/', authenticate, userController.getNotifications);

--- a/tests/userControllerTest.js
+++ b/tests/userControllerTest.js
@@ -427,25 +427,6 @@ describe('User controller', () => {
       expect(response.status).to.equal(400);
       expect(response.body.message).to.equal('Error: User doen\'t exist');
     });
-    it('should return error if token is compromised', async () => {
-      const response = await chai
-        .request(app)
-        .get(`${rootUrl}/user/followed/${userCId}`)
-        .set('authorization', 'userTokenHasBeenCompromised')
-        .send();
-
-      expect(response).to.have.status(401);
-      expect(response.body.message).to.equal('jwt malformed');
-    });
-    it('should return error if token is not given', async () => {
-      const response = await chai
-        .request(app)
-        .get(`${rootUrl}/user/followed/${userCId}`)
-        .send();
-
-      expect(response).to.have.status(401);
-      expect(response.body.message).to.equal('Unauthorized request, please login');
-    });
   });
   describe('GET /user/followers/:userId', () => {
     let userAToken;
@@ -504,25 +485,6 @@ describe('User controller', () => {
         .send();
       expect(response.status).to.equal(400);
       expect(response.body.message).to.equal('Error: User doen\'t exist');
-    });
-    it('should return error if token is compromised', async () => {
-      const response = await chai
-        .request(app)
-        .get(`${rootUrl}/user/followers/${userCId}`)
-        .set('authorization', 'userTokenHasBeenCompromised')
-        .send();
-
-      expect(response).to.have.status(401);
-      expect(response.body.message).to.equal('jwt malformed');
-    });
-    it('should return error if token is not given', async () => {
-      const response = await chai
-        .request(app)
-        .get(`${rootUrl}/user/followers/${userCId}`)
-        .send();
-
-      expect(response).to.have.status(401);
-      expect(response.body.message).to.equal('Unauthorized request, please login');
     });
   });
   describe('PUT /user/notification/on/:setting', () => {


### PR DESCRIPTION
**What does this PR do?**
This PR enables unauthorized users to see 'followers' and 'following' of specified users

**Description of Task to be completed?**

- remove auth from route GET /user/followed/:userId
- remove auth from route GET /user/followers/:userId
- refactor test conformity

**How should this PR be manually tested**
- clone the repo
- run `npm install`
- run `npm test`


**Any background context you want to provide?**
N/A

**What are the relevant pivotal tracker stories?**
 #162160512

**Screenshots (if appropriate)**
N/A

**Questions:**
None